### PR TITLE
Remove triggerLoad using isElementInViewPort

### DIFF
--- a/__tests__/components/Image.js
+++ b/__tests__/components/Image.js
@@ -1,11 +1,9 @@
 import Image from '../../src/components/Image';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import {mount} from 'enzyme/build';
 
 const mockLozad = {
-  observe: jest.fn(),
-  triggerLoad: jest.fn()
+  observe: jest.fn()
 };
 
 jest.mock('../../src/lozad', () => {
@@ -17,7 +15,9 @@ jest.mock('../../src/lozad', () => {
 const testRendererOptions = {
   createNodeMock: () => {
     return {
-      getBoundingClientRect: () => { return {}; }
+      getBoundingClientRect: () => {
+        return {};
+      }
     };
   }
 };
@@ -30,70 +30,127 @@ const testConfig = {
 describe('Image', () => {
   beforeEach(() => {
     mockLozad.observe.mockClear();
-    mockLozad.triggerLoad.mockClear();
   });
 
   it('should not crash when dont have expected parameters', () => {
-    renderer.create(<Image src={undefined} config={undefined}/>, testRendererOptions);
+    renderer.create(
+      <Image src={undefined} config={undefined} />,
+      testRendererOptions
+    );
   });
 
   it('should render with minimum parameters', () => {
     expect(
-      renderer.create(<Image src={'https://image.here.com/logo.png'} config={testConfig}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image src={'https://image.here.com/logo.png'} config={testConfig} />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with domain that don\'t have scheme', () => {
     expect(
-      renderer.create(<Image src={'https://image.here.com/logo.png'} config={{domain: 'test.com', apiKey: 'abc123'}}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'https://image.here.com/logo.png'}
+            config={{ domain: 'test.com', apiKey: 'abc123' }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with alt text', () => {
     expect(
-      renderer.create(<Image src={'https://image.here.com/logo.png'} config={testConfig} alt={'yo!'}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'https://image.here.com/logo.png'}
+            config={testConfig}
+            alt={'yo!'}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with lazy loading disabled', () => {
     expect(
-      renderer.create(<Image src={'https://image.here.com/logo.png'} config={testConfig} lazy={false}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'https://image.here.com/logo.png'}
+            config={testConfig}
+            lazy={false}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with operation that have arguments', () => {
     expect(
-      renderer.create(<Image src={'https://image.here.com/logo.png'} config={testConfig} op={'fit?size=100x200'}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'https://image.here.com/logo.png'}
+            config={testConfig}
+            op={'fit?size=100x200'}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should not apply URL transformation for data: sources', () => {
     expect(
-      renderer.create(<Image src={'data:ABCDEF'} config={testConfig} op={'fit?size=100x200'}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'data:ABCDEF'}
+            config={testConfig}
+            op={'fit?size=100x200'}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should replace source that starts with // to https://', () => {
     expect(
-      renderer.create(<Image src={'//image.here.com/logo.png'} config={testConfig} op={'fit?size=100x200'}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'//image.here.com/logo.png'}
+            config={testConfig}
+            op={'fit?size=100x200'}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
-  });
-
-  it('should setup lazy loading when props changed', () => {
-    const image = mount(<Image src={'//image.here.com/logo.png'} config={testConfig} op={'fit?size=100x200'}/>);
-    expect(mockLozad.triggerLoad).toHaveBeenCalledTimes(1);
-
-    image.setProps({
-      src: '//newimage.here.com'
-    });
-
-    expect(mockLozad.triggerLoad).toHaveBeenCalledTimes(2);
   });
 
   it('should encode image source if it has query params', () => {
     expect(
-      renderer.create(<Image src={'//image.here.com/logo.png?param=1'} config={testConfig} op={'fit?size=100x200'}/>, testRendererOptions).toJSON()
+      renderer
+        .create(
+          <Image
+            src={'//image.here.com/logo.png?param=1'}
+            config={testConfig}
+            op={'fit?size=100x200'}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
-
 });

--- a/__tests__/components/Picture.js
+++ b/__tests__/components/Picture.js
@@ -1,11 +1,9 @@
 import Picture from '../../src/components/Picture';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import {mount} from 'enzyme';
 
 const mockLozad = {
-  observe: jest.fn(),
-  triggerLoad: jest.fn()
+  observe: jest.fn()
 };
 
 jest.mock('../../src/lozad', () => {
@@ -17,7 +15,9 @@ jest.mock('../../src/lozad', () => {
 const testRendererOptions = {
   createNodeMock: () => {
     return {
-      getBoundingClientRect: () => { return {}; }
+      getBoundingClientRect: () => {
+        return {};
+      }
     };
   }
 };
@@ -26,8 +26,8 @@ const testConfig = {
   domain: 'https://test.com',
   apiKey: 'abc123',
   breakpoints: {
-    lg: {media: '(min-width: 990px)'},
-    md: {media: '(min-width: 640px)'},
+    lg: { media: '(min-width: 990px)' },
+    md: { media: '(min-width: 640px)' },
     sm: {}
   }
 };
@@ -35,129 +35,136 @@ const testConfig = {
 describe('Picture', () => {
   beforeEach(() => {
     mockLozad.observe.mockClear();
-    mockLozad.triggerLoad.mockClear();
   });
 
   it('should not crash if one of the breakpoints don\'t have source', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          breakpoints={{
-            sm: {},
-            md: {src: undefined, op: 'resize?size=200'},
-            lg: {src: 'https://here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            breakpoints={{
+              sm: {},
+              md: { src: undefined, op: 'resize?size=200' },
+              lg: { src: 'https://here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with minimum parameters', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: 'https://here.com/logo.png', op: 'resize?size=200'},
-            lg: {src: 'https://here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: 'https://here.com/logo.png', op: 'resize?size=200' },
+              lg: { src: 'https://here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render when not lazy', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          lazy={false}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: 'https://here.com/logo.png', op: 'resize?size=200'},
-            lg: {src: 'https://here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            lazy={false}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: 'https://here.com/logo.png', op: 'resize?size=200' },
+              lg: { src: 'https://here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should render with alt attribute', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          alt={'YO!'}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: 'https://here.com/logo.png', op: 'resize?size=200'},
-            lg: {src: 'https://here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            alt={'YO!'}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: 'https://here.com/logo.png', op: 'resize?size=200' },
+              lg: { src: 'https://here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should not apply URL transformation for data: sources', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          alt={'YO!'}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: 'data:ABCDEF', op: 'resize?size=200'},
-            lg: {src: 'https://here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            alt={'YO!'}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: 'data:ABCDEF', op: 'resize?size=200' },
+              lg: { src: 'https://here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 
   it('should replace source that starts with // to https://', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          alt={'YO!'}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: '//here.com/logo.png', op: 'resize?size=200'},
-            lg: {src: '//here.com/logo-large.png'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            alt={'YO!'}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: '//here.com/logo.png', op: 'resize?size=200' },
+              lg: { src: '//here.com/logo-large.png' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
-  });
-
-  it('should setup lazy loading when props changed', () => {
-    const picture = mount(<Picture config={testConfig}
-      alt={'YO!'}
-      breakpoints={{
-        sm: {hide: true},
-        md: {src: '//here.com/logo.png', op: 'resize?size=200'},
-        lg: {src: '//here.com/logo-large.png'}
-      }}/>
-    );
-    expect(mockLozad.triggerLoad).toHaveBeenCalledTimes(1);
-
-    picture.setProps({
-      breapoints: {
-        md: {src: '//here.com/new-logo.png', op: 'resize?size=200'}
-      }
-    });
-
-    expect(mockLozad.triggerLoad).toHaveBeenCalledTimes(2);
   });
 
   it('should encode sources that have query params', () => {
     expect(
-      renderer.create(
-        <Picture config={testConfig}
-          alt={'YO!'}
-          breakpoints={{
-            sm: {hide: true},
-            md: {src: '//here.com/logo.png?param=1', op: 'resize?size=200'},
-            lg: {src: '//here.com/logo-large.png?param=2'}
-          }}
-        />, testRendererOptions
-      ).toJSON()
+      renderer
+        .create(
+          <Picture
+            config={testConfig}
+            alt={'YO!'}
+            breakpoints={{
+              sm: { hide: true },
+              md: { src: '//here.com/logo.png?param=1', op: 'resize?size=200' },
+              lg: { src: '//here.com/logo-large.png?param=2' }
+            }}
+          />,
+          testRendererOptions
+        )
+        .toJSON()
     ).toMatchSnapshot();
   });
 });

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import lozad from '../lozad';
-import {isElementInViewport, prepareSource} from '../util';
+import { prepareSource } from '../util';
 
 class Image extends Component {
   constructor(props) {
@@ -31,31 +31,34 @@ class Image extends Component {
       const el = this.imgRef.current;
       const lozadInstance = lozad(el, {
         threshold: 0.01,
-        rootMargin: '40px 0px 0px 0px',
+        rootMargin: '40px 0px 0px 0px'
       });
-      if (isElementInViewport(el)) {
-        lozadInstance.triggerLoad(el);
-      } else {
-        lozadInstance.observe();
-      }
+
+      lozadInstance.observe();
     }
   }
 
   render() {
-    const {config, src, alt, op, lazy, ...otherProps} = this.props;
+    const { config, src, alt, op, lazy, ...otherProps } = this.props;
 
     if (!src || !config) {
       return null;
     }
 
     const imgAttrs = {};
-    const imgSrc = src.indexOf('data:') === 0 ?
-      src :
-      `${config.domain.includes('//') ? '' : '//'}${config.domain}/api/2/img/${prepareSource(src)}/${op}${op.includes('?') ? '&' : '?'}auth=${config.apiKey}`;
+    const imgSrc =
+      src.indexOf('data:') === 0
+        ? src
+        : `${config.domain.includes('//') ? '' : '//'}${
+          config.domain
+        }/api/2/img/${prepareSource(src)}/${op}${
+          op.includes('?') ? '&' : '?'
+        }auth=${config.apiKey}`;
 
     if (lazy) {
       imgAttrs['data-src'] = imgSrc;
-      imgAttrs['src'] = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+      imgAttrs['src'] =
+        'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
     } else {
       imgAttrs['src'] = imgSrc;
     }
@@ -63,9 +66,7 @@ class Image extends Component {
       imgAttrs.alt = alt;
     }
 
-    return (
-      <img {...imgAttrs} {...otherProps} ref={this.imgRef}/>
-    );
+    return <img {...imgAttrs} {...otherProps} ref={this.imgRef} />;
   }
 }
 

--- a/src/components/Picture.js
+++ b/src/components/Picture.js
@@ -1,17 +1,15 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import lozad from '../lozad';
-import {getBrowser, isElementInViewport, prepareSource} from '../util';
+import { getBrowser, prepareSource } from '../util';
 
 const browser = getBrowser();
 
-const IE9Wrapper = (props) => {
+const IE9Wrapper = props => {
   const isIE9 = browser.name === 'MSIE' && browser.version === '9';
 
   if (isIE9) {
-    return <video style={{display: 'none'}}>
-      {props.children}
-    </video>;
+    return <video style={{ display: 'none' }}>{props.children}</video>;
   }
 
   return props.children;
@@ -50,14 +48,7 @@ class Picture extends Component {
         }
       });
 
-      if (isElementInViewport(el)) {
-        lozadInstance.triggerLoad(el);
-        if (window.picturefill && typeof window.picturefill === 'function') {
-          window.picturefill();
-        }
-      } else {
-        lozadInstance.observe();
-      }
+      lozadInstance.observe();
     }
   }
 
@@ -71,11 +62,15 @@ class Picture extends Component {
     }
     const op = bp.op || 'optimise';
 
-    return `${config.domain.includes('//') ? '' : '//'}${config.domain}/api/2/img/${prepareSource(bp.src)}/${op}${op.includes('?') ? '&' : '?'}auth=${config.apiKey}`;
+    return `${config.domain.includes('//') ? '' : '//'}${
+      config.domain
+    }/api/2/img/${prepareSource(bp.src)}/${op}${
+      op.includes('?') ? '&' : '?'
+    }auth=${config.apiKey}`;
   }
 
   render() {
-    const {config, breakpoints, alt, lazy, ...rest} = this.props;
+    const { config, breakpoints, alt, lazy, ...rest } = this.props;
 
     if (!config) {
       return null;
@@ -83,15 +78,22 @@ class Picture extends Component {
 
     let defaultBp;
     return (
-      <picture {...rest} data-alt={alt} ref={this.pictureRef} key={JSON.stringify(this.props)}>
+      <picture
+        {...rest}
+        data-alt={alt}
+        ref={this.pictureRef}
+        key={JSON.stringify(this.props)}
+      >
         <IE9Wrapper>
           {Object.keys(breakpoints).map(b => {
             const bpConfig = config.breakpoints[b];
             const bp = breakpoints[b];
 
             if (!bpConfig) {
-            // eslint-disable-next-line no-console
-              console.warn(`pixboost-react: Can't find breakpoint config for ${b}`);
+              // eslint-disable-next-line no-console
+              console.warn(
+                `pixboost-react: Can't find breakpoint config for ${b}`
+              );
               return;
             }
             if (!bpConfig.media) {
@@ -100,16 +102,20 @@ class Picture extends Component {
             }
 
             return (
-              <source key={b} media={bpConfig.media} srcSet={Picture.bpSrc(config, bp)}/>
+              <source
+                key={b}
+                media={bpConfig.media}
+                srcSet={Picture.bpSrc(config, bp)}
+              />
             );
           })}
         </IE9Wrapper>
-        {defaultBp && !lazy &&
-          <img src={Picture.bpSrc(config, defaultBp)} alt={alt}/>
-        }
-        {defaultBp && lazy &&
-          <source srcSet={Picture.bpSrc(config, defaultBp)}/>
-        }
+        {defaultBp && !lazy && (
+          <img src={Picture.bpSrc(config, defaultBp)} alt={alt} />
+        )}
+        {defaultBp && lazy && (
+          <source srcSet={Picture.bpSrc(config, defaultBp)} />
+        )}
       </picture>
     );
   }

--- a/src/util.js
+++ b/src/util.js
@@ -3,39 +3,32 @@ function getBrowser() {
     return {};
   }
 
-  const ua=window.navigator.userAgent;
+  const ua = window.navigator.userAgent;
   let tem;
-  let M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+  let M =
+    ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) ||
+    [];
 
-  if(/trident/i.test(M[1])){
-    tem=/\brv[ :]+(\d+)/g.exec(ua) || [];
-    return {name:'IE',version:(tem[1]||'')};
+  if (/trident/i.test(M[1])) {
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+    return { name: 'IE', version: tem[1] || '' };
   }
-  if(M[1]==='Chrome'){
-    tem=ua.match(/\bOPR|Edge\/(\d+)/);
-    if(tem!=null)   {return {name:'Opera', version:tem[1]};}
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\bOPR|Edge\/(\d+)/);
+    if (tem != null) {
+      return { name: 'Opera', version: tem[1] };
+    }
   }
-  M=M[2]? [M[1], M[2]]: [window.navigator.appName, window.navigator.appVersion, '-?'];
-  if((tem=ua.match(/version\/(\d+)/i))!=null) {M.splice(1,1,tem[1]);}
+  M = M[2]
+    ? [M[1], M[2]]
+    : [window.navigator.appName, window.navigator.appVersion, '-?'];
+  if ((tem = ua.match(/version\/(\d+)/i)) != null) {
+    M.splice(1, 1, tem[1]);
+  }
   return {
     name: M[0],
     version: M[1]
   };
-}
-
-function isElementInViewport(el) {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return false;
-  }
-
-  const rect = el.getBoundingClientRect();
-
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
 }
 
 function prepareSource(src) {
@@ -52,4 +45,4 @@ function prepareSource(src) {
   return encodedSrc;
 }
 
-export {getBrowser, isElementInViewport, prepareSource};
+export { getBrowser, prepareSource };


### PR DESCRIPTION
`isElementInViewPort` is using `getBoundingClientRect` which might hurt performance if performed on many images. Remove it and relying on Intersection Observer API.